### PR TITLE
feat(user): 전역 예외처리 클래스 설정,  커스텀 예외 처리

### DIFF
--- a/src/main/java/io/dustin/salesmgmt/common/exception/custom/InvalidDepartmentException.java
+++ b/src/main/java/io/dustin/salesmgmt/common/exception/custom/InvalidDepartmentException.java
@@ -1,0 +1,8 @@
+package io.dustin.salesmgmt.common.exception.custom;
+
+public class InvalidDepartmentException extends RuntimeException {
+    public  InvalidDepartmentException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/io/dustin/salesmgmt/common/exception/global/GlobalExceptionHandler.java
+++ b/src/main/java/io/dustin/salesmgmt/common/exception/global/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package io.dustin.salesmgmt.common.exception.global;
+
+import io.dustin.salesmgmt.common.exception.custom.InvalidDepartmentException;
+import io.dustin.salesmgmt.common.response.CommonResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidDepartmentException.class)
+    public ResponseEntity<CommonResponse<String>> handleInvalidDepartment(InvalidDepartmentException ex) {
+        return ResponseEntity.badRequest().body(
+                CommonResponse.of(400, ex.getMessage(), null)
+        );
+    }
+}

--- a/src/main/java/io/dustin/salesmgmt/user/application/service/GetUsersInfoService.java
+++ b/src/main/java/io/dustin/salesmgmt/user/application/service/GetUsersInfoService.java
@@ -1,6 +1,7 @@
 package io.dustin.salesmgmt.user.application.service;
 
 import io.dustin.salesmgmt.common.annotation.UseCase;
+import io.dustin.salesmgmt.common.exception.custom.InvalidDepartmentException;
 import io.dustin.salesmgmt.user.application.dto.MsGraphUserInfo;
 import io.dustin.salesmgmt.user.application.port.in.GetUsersInfoUseCase;
 import io.dustin.salesmgmt.user.application.port.in.query.GetUsersInfoQuery;
@@ -21,7 +22,7 @@ public class GetUsersInfoService implements GetUsersInfoUseCase {
         List<MsGraphUserInfo> getUsersInfo = loadUserInfoPort.getUsersInfoFromMsGraph(departmentsName);
 
         if (getUsersInfo == null || getUsersInfo.isEmpty()){
-            throw new IllegalArgumentException("올바른 부서 정보를 입력해야 합니다.");
+            throw new InvalidDepartmentException("올바른 부서 정보를 입력해야 합니다.");
         }
 
 


### PR DESCRIPTION
1. 공통모듈에 전역 에러처리 클래스를 만들어  추후 다른 도메인에서도 사용하게끔 구현
2. 커스텀 예외를 만들어 부서의 대한 비즈니스 규칙이 위반되었을 때 에러를 구체적으로 명시하여 던지도록 함